### PR TITLE
Pass instance to DRF serializers

### DIFF
--- a/hvad/contrib/restframework/serializers.py
+++ b/hvad/contrib/restframework/serializers.py
@@ -79,7 +79,7 @@ class TranslationsMixin:
             })
             NestedSerializer = type('NestedSerializer', (BaseSerializer,), {'Meta': NestedMeta})
 
-            kwargs = {'many': True}
+            kwargs = {'many': True, 'instance': self.instance}
             if isinstance(self, TranslatableModelMixin):
                 kwargs['required'] = False
             return NestedSerializer, kwargs

--- a/hvad/contrib/restframework/utils.py
+++ b/hvad/contrib/restframework/utils.py
@@ -34,8 +34,20 @@ class TranslationListSerializer(serializers.ListSerializer):
             })
 
         ret, errors = {}, {}
+        instance = self.child.instance
+        existing_objects = (
+            {
+                obj.language_code: obj
+                for obj in instance._meta.translations_model.objects.filter(
+                    master=instance
+                )
+            }
+            if instance
+            else {}
+        )
         for language, translation in data.items():
             try:
+                self.child.instance = existing_objects.get(language)
                 validated = self.child.run_validation(translation)
             except ValidationError as exc:
                 errors[language] = exc.detail


### PR DESCRIPTION
Added instance to DRF serializers. This permits to handle uniqueness validation over translated models and other checks which involve model instance.